### PR TITLE
Feature/uppsf 1469 add content placeholder validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 Draft content API is a microservice that provides access to draft content stored in PAC.
-At the moment the service is a simple proxy to UPP Content API.
+The service is a simple proxy to UPP Content API.
 
 ## Installation
 
@@ -35,9 +35,16 @@ Options:
         --app-timeout="8s"                       Endpoints Timeout Duration ($APP_TIMEOUT)
         --port="8080"                            Port to listen on ($APP_PORT)
         --content-rw-endpoint="..."              Endpoint for draft content RW ($DRAFT_CONTENT_RW_ENDPOINT)
-        --mam-endpoint="..."                     Endpoint for draft content mapper ($DRAFT_CONTENT_MAPPER_ENDPOINT)
+        --mam-endpoint="..."                     Endpoint for mapping Methode article draft content ($DRAFT_CONTENT_MAM_ENDPOINT)
+        --ucv-endpoint="..."                     Endpoint for mapping Spark article draft content ($DRAFT_CONTENT_UCV_ENDPOINT)
+        --ucphv-endpoint="..."                   Endpoint for mapping Spark content placeholder draft content ($DRAFT_CONTENT_PLACEHOLDER_UCV_ENDPOINT)
         --content-endpoint="..."                 Endpoint to get content from CAPI ($CONTENT_ENDPOINT)
         --content-api-key="..."                  API key to access CAPI ($CAPI_APIKEY)
+        --api-yml="..."                          Location of the API Swagger YML file ($API_YML)
+        --origin-IDs="..."                       Allowed originID header ($ORIGIN_IDS)
+        --methode-content-type="..."             Methode content type header ($METHODE_CONTENT_TYPE)
+        --spark-article-content-type="..."       Spark article content type header ($SPARK_ARTICLE_CONTENT_TYPE)
+        --spark-CPH-content-type="..."           Spark content placeholder type header ($SPARK_CPH_CONTENT_TYPE)
 
 
 3. Test:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Download the source code, dependencies and test dependencies:
 
 1. Run the tests and install the binary:
 
-        go test ./...
+        go test -race ./... -v
         go install
 
 2. Run the binary (using the `help` flag to see the available optional arguments):
@@ -104,4 +104,4 @@ The `/__health` and `/__gtg` check the availability of:
 
 ## Change/Rotate sealed secrets
 
-Please reffer to documentation in [pac-global-sealed-secrets-eks](https://github.com/Financial-Times/pac-global-sealed-secrets-eks/blob/master/README.md). Here are explained details how to create new, change existing sealed secrets.
+Please refer to documentation in [pac-global-sealed-secrets-eks](https://github.com/Financial-Times/pac-global-sealed-secrets-eks/blob/master/README.md). Here are explained details how to create new, change existing sealed secrets.

--- a/api/api.yml
+++ b/api/api.yml
@@ -52,6 +52,7 @@ paths:
       consumes:
         - application/json
         - application/vnd.ft-upp-article+json
+        - application/vnd.ft-upp-content-placeholder+json
       parameters:
         - name: uuid
           in: path

--- a/content/draft_content_mapper_resolver.go
+++ b/content/draft_content_mapper_resolver.go
@@ -3,43 +3,37 @@ package content
 import (
 	"errors"
 	"fmt"
-
 	"github.com/sirupsen/logrus"
 )
 
 // DraftContentMapperResolver manages the mappers available for a given originId/content-type pair.
 type DraftContentMapperResolver interface {
-
 	// Resolves and returns a DraftContentMapper implementation if present.
-	MapperForOriginIdAndContentType(originId string, contentType string) (DraftContentMapper, error)
+	MapperForOriginIdAndContentType(contentType string) (DraftContentMapper, error)
 }
 
 // NewDraftContentMapperResolver returns a DraftContentMapperResolver implementation
-func NewDraftContentMapperResolver(originIdToMapper map[string]DraftContentMapper, contentTypeToMapper map[string]DraftContentMapper) DraftContentMapperResolver {
-	return &draftContentMapperResolver{originIdToMapper, contentTypeToMapper}
+func NewDraftContentMapperResolver(contentTypeToMapper map[string]DraftContentMapper) DraftContentMapperResolver {
+	return &draftContentMapperResolver{contentTypeToMapper}
 }
 
 type draftContentMapperResolver struct {
-	originIdToMapper    map[string]DraftContentMapper
 	contentTypeToMapper map[string]DraftContentMapper
 }
 
 // MapperForOriginIdAndContentType implementation checks the content-type mapping for a mapper resolution.
-// If no mapping, it fallback to originId mapping lookup. Lookup miss always generates an error instead of returning nil values for a mapper
-func (resolver *draftContentMapperResolver) MapperForOriginIdAndContentType(originId string, contentType string) (DraftContentMapper, error) {
+func (resolver *draftContentMapperResolver) MapperForOriginIdAndContentType(contentType string) (DraftContentMapper, error) {
 
+	// note: i disagree with this approach it's no longer valid; it makes sense to get the mapper having the contentType from AuroraDB but it does not make any
+	// trying with originID in case it fails with ContentType; The reason, originID identifies who creates content,
+	// but not what content is being created, cct and spark originID are the same entity and can create different content e.g :  articles; CPH. This approach is prone to fail !
+	// originID it used to be injective, not any more.
 	contentType = stripMediaTypeParameters(contentType)
 	mapper, found := resolver.contentTypeToMapper[contentType]
 
-	if found {
-		return mapper, nil
-	}
-
-	mapper, found = resolver.originIdToMapper[originId]
-
 	if !found {
-		logrus.Infof("originIdMap: %v, contentTypeMap: %v", resolver.originIdToMapper, resolver.contentTypeToMapper)
-		return nil, errors.New(fmt.Sprintf("no mappers configured for contentType: %s and originId: %s", contentType, originId))
+		logrus.Infof("contentTypeMap: %v", resolver.contentTypeToMapper)
+		return nil, errors.New(fmt.Sprintf("no mappers configured for contentType: %s", contentType))
 	}
 
 	return mapper, nil

--- a/content/draft_content_mapper_resolver.go
+++ b/content/draft_content_mapper_resolver.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"errors"
 	"fmt"
 	"github.com/sirupsen/logrus"
 )
@@ -9,7 +8,7 @@ import (
 // DraftContentMapperResolver manages the mappers available for a given originId/content-type pair.
 type DraftContentMapperResolver interface {
 	// Resolves and returns a DraftContentMapper implementation if present.
-	MapperForOriginIdAndContentType(contentType string) (DraftContentMapper, error)
+	MapperForContentType(contentType string) (DraftContentMapper, error)
 }
 
 // NewDraftContentMapperResolver returns a DraftContentMapperResolver implementation
@@ -21,19 +20,15 @@ type draftContentMapperResolver struct {
 	contentTypeToMapper map[string]DraftContentMapper
 }
 
-// MapperForOriginIdAndContentType implementation checks the content-type mapping for a mapper resolution.
-func (resolver *draftContentMapperResolver) MapperForOriginIdAndContentType(contentType string) (DraftContentMapper, error) {
+// MapperForContentType implementation checks the content-type mapping for a mapper resolution.
+func (resolver *draftContentMapperResolver) MapperForContentType(contentType string) (DraftContentMapper, error) {
 
-	// note: i disagree with this approach it's no longer valid; it makes sense to get the mapper having the contentType from AuroraDB but it does not make any
-	// trying with originID in case it fails with ContentType; The reason, originID identifies who creates content,
-	// but not what content is being created, cct and spark originID are the same entity and can create different content e.g :  articles; CPH. This approach is prone to fail !
-	// originID it used to be injective, not any more.
 	contentType = stripMediaTypeParameters(contentType)
 	mapper, found := resolver.contentTypeToMapper[contentType]
 
 	if !found {
 		logrus.Infof("contentTypeMap: %v", resolver.contentTypeToMapper)
-		return nil, errors.New(fmt.Sprintf("no mappers configured for contentType: %s", contentType))
+		return nil, fmt.Errorf("no mappers configured for contentType: %s", contentType)
 	}
 
 	return mapper, nil

--- a/content/draft_content_mapper_resolver_test.go
+++ b/content/draft_content_mapper_resolver_test.go
@@ -13,12 +13,12 @@ func TestDraftContentMapperResolver_MapperForContentType(t *testing.T) {
 	ucv := NewDraftContentMapperService("upp-content-validator-endpoint", http.DefaultClient)
 	resolver := NewDraftContentMapperResolver(happyResolverConfig(mam, ucv))
 
-	methodeMapper, err := resolver.MapperForOriginIdAndContentType(contentType)
+	methodeMapper, err := resolver.MapperForContentType(contentType)
 
 	assert.NoError(t, err, "Fallback to originId lookup should've handled the content-type lookup miss")
 	assert.Equal(t, mam, methodeMapper, "Should return the same instance impl of DraftContentMapper")
 
-	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	uppContentValidator, err := resolver.MapperForContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.NoError(t, err, "UPP Validator relies on content-type and originId. Both are present")
 	assert.Equal(t, ucv, uppContentValidator, "Should return the same instance impl of DraftContentMapper")
@@ -29,23 +29,24 @@ func TestDraftContentMapperResolver_MissingMethodeMapping(t *testing.T) {
 	ucv := NewDraftContentMapperService("upp-content-validator-endpoint", http.DefaultClient)
 	resolver := NewDraftContentMapperResolver(cctOnlyResolverConfig(ucv))
 
-	mapper, err := resolver.MapperForOriginIdAndContentType(contentType)
+	mapper, err := resolver.MapperForContentType(contentType)
 
 	assert.Error(t, err)
 	assert.Nil(t, mapper)
 
-	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	uppContentValidator, err := resolver.MapperForContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.NoError(t, err, "Fallback to originId lookup should've handled the content-type lookup miss")
 	assert.Equal(t, ucv, uppContentValidator, "Should return the same instance impl of DraftContentMapper")
 
 }
+
 func TestDraftContentMapperResolver_MissingSparkMapping(t *testing.T) {
 
 	mam := NewDraftContentMapperService("methode-endpoint", http.DefaultClient)
 	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mam))
 
-	mapper, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	mapper, err := resolver.MapperForContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.Error(t, err)
 	assert.Nil(t, mapper)

--- a/content/draft_content_mapper_resolver_test.go
+++ b/content/draft_content_mapper_resolver_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDraftContentMapperResolver_MapperForOriginIdAndContentType(t *testing.T) {
+func TestDraftContentMapperResolver_MapperForContentType(t *testing.T) {
 
 	mam := NewDraftContentMapperService("methode-endpoint", http.DefaultClient)
 	ucv := NewDraftContentMapperService("upp-content-validator-endpoint", http.DefaultClient)
 	resolver := NewDraftContentMapperResolver(happyResolverConfig(mam, ucv))
 
-	methodeMapper, err := resolver.MapperForOriginIdAndContentType("methode-web-pub", "application/andromeda; charset=klingon")
+	methodeMapper, err := resolver.MapperForOriginIdAndContentType(contentType)
 
 	assert.NoError(t, err, "Fallback to originId lookup should've handled the content-type lookup miss")
 	assert.Equal(t, mam, methodeMapper, "Should return the same instance impl of DraftContentMapper")
 
-	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("cct", "application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.NoError(t, err, "UPP Validator relies on content-type and originId. Both are present")
 	assert.Equal(t, ucv, uppContentValidator, "Should return the same instance impl of DraftContentMapper")
@@ -29,12 +29,12 @@ func TestDraftContentMapperResolver_MissingMethodeMapping(t *testing.T) {
 	ucv := NewDraftContentMapperService("upp-content-validator-endpoint", http.DefaultClient)
 	resolver := NewDraftContentMapperResolver(cctOnlyResolverConfig(ucv))
 
-	mapper, err := resolver.MapperForOriginIdAndContentType("methode-web-pub", "application/json")
+	mapper, err := resolver.MapperForOriginIdAndContentType(contentType)
 
 	assert.Error(t, err)
 	assert.Nil(t, mapper)
 
-	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("cct", "application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	uppContentValidator, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.NoError(t, err, "Fallback to originId lookup should've handled the content-type lookup miss")
 	assert.Equal(t, ucv, uppContentValidator, "Should return the same instance impl of DraftContentMapper")
@@ -43,30 +43,29 @@ func TestDraftContentMapperResolver_MissingMethodeMapping(t *testing.T) {
 func TestDraftContentMapperResolver_MissingSparkMapping(t *testing.T) {
 
 	mam := NewDraftContentMapperService("methode-endpoint", http.DefaultClient)
-	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mam, "methode-web-pub"))
+	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mam))
 
-	mapper, err := resolver.MapperForOriginIdAndContentType("cct", "application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
+	mapper, err := resolver.MapperForOriginIdAndContentType("application/vnd.ft-upp-article+json; version=1.0; charset=utf-8")
 
 	assert.Error(t, err)
 	assert.Nil(t, mapper)
 }
 
-func happyResolverConfig(mam DraftContentMapper, ucv DraftContentMapper) (originIdToMapper map[string]DraftContentMapper, contentTypeToMapper map[string]DraftContentMapper) {
+func happyResolverConfig(mam DraftContentMapper, ucv DraftContentMapper) (contentTypeToMapper map[string]DraftContentMapper) {
 	return map[string]DraftContentMapper{
-			"methode-web-pub": mam,
-		}, map[string]DraftContentMapper{
-			"application/vnd.ft-upp-article+json": ucv,
-		}
-}
-
-func cctOnlyResolverConfig(ucv DraftContentMapper) (originIdToMapper map[string]DraftContentMapper, contentTypeToMapper map[string]DraftContentMapper) {
-	return map[string]DraftContentMapper{}, map[string]DraftContentMapper{
-		"application/vnd.ft-upp-article+json": ucv,
+		contentType:        mam,
+		contentTypeArticle: ucv,
 	}
 }
 
-func methodeOnlyResolverConfig(mam DraftContentMapper, originId string) (originIdToMapper map[string]DraftContentMapper, contentTypeToMapper map[string]DraftContentMapper) {
+func cctOnlyResolverConfig(ucv DraftContentMapper) (contentTypeToMapper map[string]DraftContentMapper) {
 	return map[string]DraftContentMapper{
-		originId: mam,
-	}, map[string]DraftContentMapper{}
+		contentTypeArticle: ucv,
+	}
+}
+
+func methodeOnlyResolverConfig(mam DraftContentMapper) (contentTypeToMapper map[string]DraftContentMapper) {
+	return map[string]DraftContentMapper{
+		contentType: mam,
+	}
 }

--- a/content/draft_content_methode_mapper_test.go
+++ b/content/draft_content_methode_mapper_test.go
@@ -22,7 +22,7 @@ func TestMapper(t *testing.T) {
 
 	m := NewDraftContentMapperService(server.URL, fthttp.NewClientWithDefaultTimeout("PAC", "awesome-service"))
 
-	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), "application/json")
+	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), contentType)
 
 	assert.NoError(t, err)
 	defer body.Close()
@@ -38,7 +38,7 @@ func TestMapperError(t *testing.T) {
 
 	m := NewDraftContentMapperService(server.URL, fthttp.NewClientWithDefaultTimeout("PAC", "awesome-service"))
 
-	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), "application/json")
+	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), contentType)
 
 	assert.Error(t, err)
 	assert.Nil(t, body)
@@ -51,7 +51,7 @@ func TestMapperClientError(t *testing.T) {
 
 	m := NewDraftContentMapperService(server.URL, fthttp.NewClientWithDefaultTimeout("PAC", "awesome-service"))
 
-	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), "application/json")
+	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), contentType)
 
 	assert.Error(t, err)
 	assert.Nil(t, body)
@@ -66,7 +66,7 @@ func TestMapperBadContent(t *testing.T) {
 
 	m := NewDraftContentMapperService(server.URL, fthttp.NewClientWithDefaultTimeout("PAC", "awesome-service"))
 
-	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), "application/json")
+	body, err := m.MapNativeContent(tidutils.TransactionAwareContext(context.Background(), testTID), contentUUID, ioutil.NopCloser(strings.NewReader(nativeBody)), contentType)
 
 	assert.Error(t, err)
 	assert.Nil(t, body)
@@ -77,7 +77,7 @@ func mockMapperHttpServer(t *testing.T, status int, expectedBody string, respons
 		assert.Equal(t, "POST", r.Method, "HTTP method")
 		assert.Equal(t, "/map", r.URL.Path)
 		assert.Equal(t, "suggest", r.URL.Query().Get("mode"))
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, contentType, r.Header.Get("Content-Type"))
 		assert.Equal(t, testTID, r.Header.Get(tidutils.TransactionIDHeader), tidutils.TransactionIDHeader)
 
 		by, err := ioutil.ReadAll(r.Body)

--- a/content/draft_content_rw.go
+++ b/content/draft_content_rw.go
@@ -45,6 +45,7 @@ func (rw *draftContentRW) Read(ctx context.Context, contentUUID string) (io.Read
 	tid, _ := tidutils.GetTransactionIDFromContext(ctx)
 	readLog := log.WithField(tidutils.TransactionIDKey, tid).WithField("uuid", contentUUID)
 
+	// note : retrieves content from generic-Aurora-rw, the endpoint returns the same unaltered data (postman)
 	resp, err := rw.readNativeContent(ctx, contentUUID)
 	if err != nil {
 		readLog.WithError(err).Error("Error making the HTTP request to content RW")
@@ -58,14 +59,16 @@ func (rw *draftContentRW) Read(ctx context.Context, contentUUID string) (io.Read
 		nativeContent, err = rw.constructNativeDocumentForMapper(ctx, resp.Body, resp.Header.Get("Last-Modified-RFC3339"), resp.Header.Get("Write-Request-Id"))
 
 		if err == nil {
-			contentType := resp.Header.Get("Content-Type")
-			mapper, resolverErr := rw.resolver.MapperForOriginIdAndContentType(resp.Header.Get("X-Origin-System-Id"), contentType)
+			// note aurora returns the right header for CPH (application/vnd.ft-upp-content-placeholder+json).
+			contentType := resp.Header.Get(contentTypeHeader)
+			mapper, resolverErr := rw.resolver.MapperForOriginIdAndContentType(contentType)
 
 			if resolverErr != nil {
 				readLog.WithError(resolverErr).Error("Unable to map content")
 				return nil, resolverErr
 			}
 
+			// Note: validates content to upp-content-placeholder-validator
 			mappedContent, err = mapper.MapNativeContent(ctx, contentUUID, nativeContent, contentType)
 
 			if err != nil {
@@ -118,7 +121,7 @@ func (rw *draftContentRW) constructNativeDocumentForMapper(ctx context.Context, 
 		readLog.WithError(err).Error("unable to unmarshal native content")
 		return nil, err
 	}
-
+	// note : this two additions break CPH validation !
 	rawNativeDoc["lastModified"] = lastModified
 	rawNativeDoc["draftReference"] = writeRef
 

--- a/content/draft_content_spark_mapper.go
+++ b/content/draft_content_spark_mapper.go
@@ -58,8 +58,8 @@ func (mapper *sparkDraftContentMapper) MapNativeContent(ctx context.Context, con
 					contentUUID, err)}
 		}
 
-		responseBody := map[string]interface{}{}
-		err = json.Unmarshal(responseBytes, responseBody)
+		responseBody := make(map[string]interface{})
+		err = json.Unmarshal(responseBytes, &responseBody)
 
 		if err != nil {
 			return nil, MapperError{resp.StatusCode,

--- a/content/handler.go
+++ b/content/handler.go
@@ -14,7 +14,7 @@ import (
 
 	tidutils "github.com/Financial-Times/transactionid-utils-go"
 	"github.com/husobee/vestigo"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,8 +33,9 @@ var (
 	}
 
 	allowedContentTypes = map[string]struct{}{
-		"application/json":                    {},
-		"application/vnd.ft-upp-article+json": {},
+		"application/json":                                {},
+		"application/vnd.ft-upp-article+json":             {},
+		"application/vnd.ft-upp-content-placeholder+json": {},
 	}
 )
 

--- a/content/handler.go
+++ b/content/handler.go
@@ -27,16 +27,8 @@ const (
 )
 
 var (
-	allowedOriginSystemIdValues = map[string]struct{}{
-		"methode-web-pub": {},
-		"cct":             {},
-	}
-
-	allowedContentTypes = map[string]struct{}{
-		"application/json":                                {},
-		"application/vnd.ft-upp-article+json":             {},
-		"application/vnd.ft-upp-content-placeholder+json": {},
-	}
+	AllowedOriginSystemIdValues = map[string]struct{}{}
+	AllowedContentTypes         = map[string]struct{}{}
 )
 
 type Handler struct {
@@ -224,7 +216,7 @@ func validateUUID(u string) error {
 
 func validateOrigin(id string) (string, error) {
 	var err error
-	if _, found := allowedOriginSystemIdValues[id]; !found {
+	if _, found := AllowedOriginSystemIdValues[id]; !found {
 		err = errors.New(fmt.Sprintf("unsupported or missing value for X-Origin-System-Id: %v", id))
 	}
 
@@ -235,7 +227,7 @@ func validateContentType(contentType string) (string, error) {
 	strippedType := stripMediaTypeParameters(contentType)
 
 	var err error
-	if _, found := allowedContentTypes[strippedType]; !found {
+	if _, found := AllowedContentTypes[strippedType]; !found {
 		err = errors.New(fmt.Sprintf("unsupported or missing value for Content-Type: %v", contentType))
 	}
 

--- a/content/handler.go
+++ b/content/handler.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	AllowedOriginSystemIdValues = map[string]struct{}{}
+	AllowedOriginSystemIDValues = map[string]struct{}{}
 	AllowedContentTypes         = map[string]struct{}{}
 )
 
@@ -216,7 +216,7 @@ func validateUUID(u string) error {
 
 func validateOrigin(id string) (string, error) {
 	var err error
-	if _, found := AllowedOriginSystemIdValues[id]; !found {
+	if _, found := AllowedOriginSystemIDValues[id]; !found {
 		err = errors.New(fmt.Sprintf("unsupported or missing value for X-Origin-System-Id: %v", id))
 	}
 

--- a/content/handler_test.go
+++ b/content/handler_test.go
@@ -238,7 +238,7 @@ func TestWriteMethodeNativeContent(t *testing.T) {
 		contentTypeHeader:            contentType,
 	}
 
-	AllowedOriginSystemIdValues = map[string]struct{}{
+	AllowedOriginSystemIDValues = map[string]struct{}{
 		originIDMethodeTest: {},
 	}
 
@@ -278,7 +278,7 @@ func TestWriteSparkNativeContent(t *testing.T) {
 		contentTypeHeader:            contentTypeArticle + "; version=1.0; charset=utf-8",
 	}
 
-	AllowedOriginSystemIdValues = map[string]struct{}{
+	AllowedOriginSystemIDValues = map[string]struct{}{
 		originIDcctTest: {},
 	}
 
@@ -378,7 +378,7 @@ func TestWriteNativeContentInvalidContentType(t *testing.T) {
 	contentUUID := uuid.NewV4().String()
 	draftBody := "{\"foo\":\"bar\"}"
 
-	AllowedOriginSystemIdValues = map[string]struct{}{
+	AllowedOriginSystemIDValues = map[string]struct{}{
 		originIDcctTest: {},
 	}
 
@@ -409,7 +409,7 @@ func TestWriteNativeContentWriteError(t *testing.T) {
 	contentUUID := uuid.NewV4().String()
 	draftBody := "{\"foo\":\"bar\"}"
 
-	AllowedOriginSystemIdValues = map[string]struct{}{
+	AllowedOriginSystemIDValues = map[string]struct{}{
 		originIDMethodeTest: {},
 	}
 

--- a/content/handler_timeout_test.go
+++ b/content/handler_timeout_test.go
@@ -17,7 +17,7 @@ import (
 func TestReadTimeoutFromDraftContent(t *testing.T) {
 	contentUUID := "83a201c6-60cd-11e7-91a7-502f7ee26895"
 
-	contentRWTestServer := newDraftContentRWTestServer(300*time.Millisecond, http.StatusOK, "application/json", "methode-web-pub")
+	contentRWTestServer := newDraftContentRWTestServer(300*time.Millisecond, http.StatusOK, contentType, originIDMethodeTest)
 	mapperTestServer := newMethodeArticleMapperTestServer(0, http.StatusOK)
 	contentAPITestServer := newUppContentAPITestServer(0, http.StatusOK)
 
@@ -30,8 +30,7 @@ func TestReadTimeoutFromDraftContent(t *testing.T) {
 	client := fthttp.NewClientWithDefaultTimeout("PAC", "timing-out-awesome-service")
 
 	mapperService := NewDraftContentMapperService(mapperTestServer.server.URL, client)
-
-	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService, "methode-web-pub"))
+	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService))
 	contentRWService := NewDraftContentRWService(contentRWTestServer.server.URL, resolver, client)
 	uppApi := NewContentAPI(contentAPITestServer.server.URL, "awesomely-unique-key", client)
 
@@ -59,7 +58,7 @@ func TestReadTimeoutFromDraftContent(t *testing.T) {
 func TestReadTimeoutFromUPPContent(t *testing.T) {
 	contentUUID := "83a201c6-60cd-11e7-91a7-502f7ee26895"
 
-	contentRWTestServer := newDraftContentRWTestServer(10*time.Millisecond, http.StatusNotFound, "application/json", "methode-web-pub")
+	contentRWTestServer := newDraftContentRWTestServer(10*time.Millisecond, http.StatusNotFound, contentType, originIDMethodeTest)
 	mapperTestServer := newMethodeArticleMapperTestServer(0*time.Millisecond, http.StatusOK)
 	contentAPITestServer := newUppContentAPITestServer(300*time.Millisecond, http.StatusOK)
 
@@ -73,7 +72,7 @@ func TestReadTimeoutFromUPPContent(t *testing.T) {
 	client := fthttp.NewClientWithDefaultTimeout("PAC", "timing-out-awesome-service")
 
 	mapperService := NewDraftContentMapperService(mapperTestServer.server.URL, client)
-	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService, "methode-web-pub"))
+	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService))
 
 	contentRWService := NewDraftContentRWService(contentRWTestServer.server.URL, resolver, client)
 	uppApi := NewContentAPI(contentAPITestServer.server.URL, "awesomely-unique-key", client)
@@ -97,7 +96,7 @@ func TestReadTimeoutFromUPPContent(t *testing.T) {
 func TestReadTimeoutFromMethodeArticleMapper(t *testing.T) {
 	contentUUID := "83a201c6-60cd-11e7-91a7-502f7ee26895"
 
-	contentRWTestServer := newDraftContentRWTestServer(10*time.Millisecond, http.StatusOK, "application/json", "methode-web-pub")
+	contentRWTestServer := newDraftContentRWTestServer(10*time.Millisecond, http.StatusOK, contentType, originIDMethodeTest)
 	mapperTestServer := newMethodeArticleMapperTestServer(300*time.Millisecond, http.StatusOK)
 	contentAPITestServer := newUppContentAPITestServer(0, http.StatusOK)
 
@@ -111,7 +110,7 @@ func TestReadTimeoutFromMethodeArticleMapper(t *testing.T) {
 	client := fthttp.NewClientWithDefaultTimeout("PAC", "timing-out-awesome-service")
 
 	mapperService := NewDraftContentMapperService(mapperTestServer.server.URL, client)
-	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService, "methode-web-pub"))
+	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService))
 
 	contentRWService := NewDraftContentRWService(contentRWTestServer.server.URL, resolver, client)
 	uppApi := NewContentAPI(contentAPITestServer.server.URL, "awesomely-unique-key", client)
@@ -141,7 +140,7 @@ func testRequest(server *httptest.Server, contentUUID string) (*http.Response, e
 func TestNativeWriteTimeout(t *testing.T) {
 	contentUUID := "83a201c6-60cd-11e7-91a7-502f7ee26895"
 
-	contentRWTestServer := newDraftContentRWTestServer(300*time.Millisecond, http.StatusOK, "application/json", "methode-web-pub")
+	contentRWTestServer := newDraftContentRWTestServer(300*time.Millisecond, http.StatusOK, contentType, originIDMethodeTest)
 	mapperTestServer := newMethodeArticleMapperTestServer(0*time.Millisecond, http.StatusOK)
 	contentAPITestServer := newUppContentAPITestServer(0*time.Millisecond, http.StatusOK)
 
@@ -154,7 +153,7 @@ func TestNativeWriteTimeout(t *testing.T) {
 	client := fthttp.NewClientWithDefaultTimeout("PAC", "timing-out-awesome-service")
 
 	mapperService := NewDraftContentMapperService(mapperTestServer.server.URL, client)
-	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService, "methode-web-pub"))
+	resolver := NewDraftContentMapperResolver(methodeOnlyResolverConfig(mapperService))
 
 	contentRWService := NewDraftContentRWService(contentRWTestServer.server.URL, resolver, client)
 	uppApi := NewContentAPI(contentAPITestServer.server.URL, "awesomely-unique-key", client)
@@ -170,8 +169,8 @@ func TestNativeWriteTimeout(t *testing.T) {
 
 	request, _ := http.NewRequest(http.MethodPut, server.URL+"/drafts/nativecontent/"+contentUUID, nil)
 	request.Header.Set(tidutils.TransactionIDHeader, testTID)
-	request.Header.Set(originSystemIdHeader, "methode-web-pub")
-	request.Header.Set(contentTypeHeader, "application/json")
+	request.Header.Set(originSystemIdHeader, originIDMethodeTest)
+	request.Header.Set(contentTypeHeader, contentType)
 
 	resp, err := client.Do(request)
 	defer resp.Body.Close()
@@ -218,7 +217,7 @@ func newMethodeArticleMapperTestServer(inducedDelay time.Duration, responseStatu
 			time.Sleep(inducedDelay)
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", contentType)
 		w.WriteHeader(responseStatus)
 		w.Write([]byte(fromMaMContent))
 	}))
@@ -233,7 +232,7 @@ func newUppContentAPITestServer(inducedDelay time.Duration, responseStatus int) 
 			m.EndpointCalled()
 			time.Sleep(inducedDelay)
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", contentType)
 		w.WriteHeader(responseStatus)
 		w.Write([]byte(fromUppContent))
 	}))

--- a/health/healthcheck.go
+++ b/health/healthcheck.go
@@ -17,15 +17,16 @@ type externalService interface {
 
 type Service struct {
 	health.HealthCheck
-	uppContentAPI  externalService
-	draftContentRW externalService
-	methodeMapper  externalService
-	sparkValidator externalService
+	uppContentAPI     externalService
+	draftContentRW    externalService
+	methodeMapper     externalService
+	sparkValidator    externalService
+	sparkCPHValidator externalService
 }
 
 func NewHealthService(appSystemCode string, appName string, appDescription string,
-	draftContent externalService, mam externalService, capi externalService, ucv externalService) *Service {
-	service := &Service{draftContentRW: draftContent, methodeMapper: mam, uppContentAPI: capi, sparkValidator: ucv}
+	draftContent externalService, mam externalService, capi externalService, ucv externalService, ucphv externalService) *Service {
+	service := &Service{draftContentRW: draftContent, methodeMapper: mam, uppContentAPI: capi, sparkValidator: ucv, sparkCPHValidator: ucphv}
 	service.SystemCode = appSystemCode
 	service.Name = appName
 	service.Description = appDescription
@@ -34,6 +35,7 @@ func NewHealthService(appSystemCode string, appName string, appDescription strin
 		service.draftContentMethodeArticleMapperCheck(),
 		service.contentAPICheck(),
 		service.draftUppContentValidatorCheck(),
+		service.draftUppContentPlaceholderValidatorCheck(),
 	}
 	return service
 }
@@ -80,6 +82,18 @@ func (service *Service) draftUppContentValidatorCheck() health.Check {
 		Severity:         1,
 		TechnicalSummary: fmt.Sprintf("Draft upp content validator is not available at %v", service.sparkValidator.Endpoint()),
 		Checker:          externalServiceChecker(service.sparkValidator, "Draft content upp-content-validator"),
+	}
+}
+
+func (service *Service) draftUppContentPlaceholderValidatorCheck() health.Check {
+	return health.Check{
+		ID:               "check-draft-upp-content-placeholder-validator",
+		BusinessImpact:   "Draft spark content placeholder cannot be provided for suggestions",
+		Name:             "Check upp-content-validator service",
+		PanicGuide:       "https://runbooks.in.ft.com/draft-content-api",
+		Severity:         1,
+		TechnicalSummary: fmt.Sprintf("Draft upp content placeholder validator is not available at %v", service.sparkCPHValidator.Endpoint()),
+		Checker:          externalServiceChecker(service.sparkValidator, "Draft content upp-content-placeholder-validator"),
 	}
 }
 

--- a/health/healthcheck_test.go
+++ b/health/healthcheck_test.go
@@ -18,8 +18,9 @@ func TestHappyHealthCheck(t *testing.T) {
 	draftContentMapper := mockHealthyExternalService()
 	cAPI := mockHealthyExternalService()
 	ucv := mockHealthyExternalService()
+	draftContentPlaceholderValidator := mockHealthyExternalService()
 
-	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, ucv)
+	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, ucv, draftContentPlaceholderValidator)
 
 	req := httptest.NewRequest("GET", "/__health", nil)
 	w := httptest.NewRecorder()
@@ -31,7 +32,7 @@ func TestHappyHealthCheck(t *testing.T) {
 	hcBody := make(map[string]interface{})
 	err := json.NewDecoder(resp.Body).Decode(&hcBody)
 	assert.NoError(t, err)
-	assert.Len(t, hcBody["checks"], 4)
+	assert.Len(t, hcBody["checks"], 5)
 	assert.True(t, hcBody["ok"].(bool))
 
 	checks := hcBody["checks"].([]interface{})
@@ -52,11 +53,13 @@ func TestUnhappyHealthCheck(t *testing.T) {
 	draftContentRW := mockHealthyExternalService()
 	draftContentMapper := mockHealthyExternalService()
 	draftContentValidator := mockHealthyExternalService()
+	draftContentPlaceholderValidator := mockHealthyExternalService()
+
 	cAPI := new(ExternalServiceMock)
 	cAPI.On("GTG").Return(errors.New("computer says no"))
 	cAPI.On("Endpoint").Return("http://cool.api.ft.com/content")
 
-	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator)
+	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator, draftContentPlaceholderValidator)
 
 	req := httptest.NewRequest("GET", "/__health", nil)
 	w := httptest.NewRecorder()
@@ -68,7 +71,7 @@ func TestUnhappyHealthCheck(t *testing.T) {
 	hcBody := make(map[string]interface{})
 	err := json.NewDecoder(resp.Body).Decode(&hcBody)
 	assert.NoError(t, err)
-	assert.Len(t, hcBody["checks"], 4)
+	assert.Len(t, hcBody["checks"], 5)
 	assert.False(t, hcBody["ok"].(bool))
 
 	checks := hcBody["checks"].([]interface{})
@@ -89,9 +92,11 @@ func TestHappyGTG(t *testing.T) {
 	draftContentRW := mockHealthyExternalService()
 	draftContentMapper := mockHealthyExternalService()
 	draftContentValidator := mockHealthyExternalService()
+	draftContentPlaceholderValidator := mockHealthyExternalService()
+
 	cAPI := mockHealthyExternalService()
 
-	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator)
+	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator, draftContentPlaceholderValidator)
 
 	req := httptest.NewRequest("GET", "/__gtg", nil)
 	w := httptest.NewRecorder()
@@ -108,11 +113,12 @@ func TestUnhappyGTG(t *testing.T) {
 	draftContentRW := mockHealthyExternalService()
 	draftContentMapper := mockHealthyExternalService()
 	draftContentValidator := mockHealthyExternalService()
+	draftContentPlaceholderValidator := mockHealthyExternalService()
 
 	cAPI := new(ExternalServiceMock)
 	cAPI.On("GTG").Return(errors.New("computer says no"))
 	cAPI.On("Endpoint").Return("http://cool.api.ft.com/content")
-	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator)
+	h := NewHealthService("", "", "", draftContentRW, draftContentMapper, cAPI, draftContentValidator, draftContentPlaceholderValidator)
 
 	req := httptest.NewRequest("GET", "/__gtg", nil)
 	w := httptest.NewRecorder()

--- a/helm/draft-content-api/templates/deployment.yaml
+++ b/helm/draft-content-api/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         app: {{ .Values.service.name }}
         visualize: "true"
     spec:
-{{- if not .Values.eksCluster }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -32,7 +31,6 @@ spec:
                 values:
                 - "{{ .Values.service.name }}"
             topologyKey: "kubernetes.io/hostname"
-{{- end }}
       containers:
       - name: {{ .Values.service.name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
@@ -40,12 +38,17 @@ spec:
         env:
         - name: DRAFT_CONTENT_RW_ENDPOINT
           value: "http://generic-rw-aurora:8080"
-        - name: DRAFT_CONTENT_MAM_ENDPOINT
-          value: "http://methode-article-mapper:8080"
-        - name: DRAFT_CONTENT_UCV_ENDPOINT
-          value: "http://upp-content-validator:8080"
-        - name: DRAFT_CONTENT_PLACEHOLDER_UCV_ENDPOINT
-          value: "http://upp-content-placeholder-validator:8080"
+        - name: DRAFT_CONTENT_MAM_CONFIG
+          value: "http://methode-article-mapper:8080|{{ .Values.methodeCT }}"
+        - name: DRAFT_CONTENT_UCV_CONFIG
+          value: "http://upp-content-validator:8080|{{ .Values.articleCT }}"
+        - name: DRAFT_CONTENT_PLACEHOLDER_UCV_CONFIG
+          value: "http://upp-content-placeholder-validator:8080|{{ .Values.CPHCT }}"
+          - name: ORIGIN_IDS
+          valueFrom:
+            configMapKeyRef:
+              name: draft-content-api-config
+              key: originID
         - name: CONTENT_ENDPOINT
           valueFrom:
             configMapKeyRef:

--- a/helm/draft-content-api/templates/deployment.yaml
+++ b/helm/draft-content-api/templates/deployment.yaml
@@ -38,17 +38,20 @@ spec:
         env:
         - name: DRAFT_CONTENT_RW_ENDPOINT
           value: "http://generic-rw-aurora:8080"
-        - name: DRAFT_CONTENT_MAM_CONFIG
-          value: "http://methode-article-mapper:8080|{{ .Values.methodeCT }}"
-        - name: DRAFT_CONTENT_UCV_CONFIG
-          value: "http://upp-content-validator:8080|{{ .Values.articleCT }}"
-        - name: DRAFT_CONTENT_PLACEHOLDER_UCV_CONFIG
-          value: "http://upp-content-placeholder-validator:8080|{{ .Values.CPHCT }}"
-          - name: ORIGIN_IDS
-          valueFrom:
-            configMapKeyRef:
-              name: draft-content-api-config
-              key: originID
+        - name: DRAFT_CONTENT_MAM_ENDPOINT
+          value: "http://methode-article-mapper:8080"
+        - name: DRAFT_CONTENT_UCV_ENDPOINT
+          value: "http://upp-content-validator:8080"
+        - name: DRAFT_CONTENT_PLACEHOLDER_UCV_ENDPOINT
+          value: "http://upp-content-placeholder-validator:8080"
+        - name: ORIGIN_IDS
+          value: "{{ .Values.originID }}"
+        - name: METHODE_CONTENT_TYPE
+          value: "{{ .Values.allowedContentTypes.methodeContentType }}"
+        - name: SPARK_ARTICLE_CONTENT_TYPE
+          value: "{{ .Values.allowedContentTypes.sparkArticleContentType }}"
+        - name: SPARK_CPH_CONTENT_TYPE
+          value:  "{{ .Values.allowedContentTypes.sparkCPHContentType }}"
         - name: CONTENT_ENDPOINT
           valueFrom:
             configMapKeyRef:

--- a/helm/draft-content-api/templates/deployment.yaml
+++ b/helm/draft-content-api/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
           value: "http://methode-article-mapper:8080"
         - name: DRAFT_CONTENT_UCV_ENDPOINT
           value: "http://upp-content-validator:8080"
+        - name: DRAFT_CONTENT_PLACEHOLDER_UCV_ENDPOINT
+          value: "http://upp-content-placeholder-validator:8080"
         - name: CONTENT_ENDPOINT
           valueFrom:
             configMapKeyRef:

--- a/helm/draft-content-api/values.yaml
+++ b/helm/draft-content-api/values.yaml
@@ -5,15 +5,10 @@ service:
 
 originID: "methode-web-pub|cct|spark-lists|spark"
 
-# test: check whether is able to load it as var env
-DraftConfig:
-  methode: "methode|http://methode-article-mapper:8080|application/json"
-  article: "article|http://upp-content-validator:8080|application/vnd.ft-upp-article+json"
-  CPH: "CPH|http://upp-content-placeholder-validator:8080|application/vnd.ft-upp-content-placeholder+json"
-
-#methodeDraftConfig: "http://methode-article-mapper:8080|application/json"
-#articleDraftConfig: "http://upp-content-validator:8080|application/vnd.ft-upp-article+json"
-#CPHDraftConfig: "http://upp-content-placeholder-validator:8080|application/vnd.ft-upp-content-placeholder+json"
+allowedContentTypes:
+  methodeContentType : "application/json"
+  sparkArticleContentType: "application/vnd.ft-upp-article+json"
+  sparkCPHContentType: "application/vnd.ft-upp-content-placeholder+json"
 
 eksCluster: false
 

--- a/helm/draft-content-api/values.yaml
+++ b/helm/draft-content-api/values.yaml
@@ -3,6 +3,18 @@ service:
   hasHealthcheck: "true"
   hasOpenAPI: "true"
 
+originID: "methode-web-pub|cct|spark-lists|spark"
+
+# test: check whether is able to load it as var env
+DraftConfig:
+  methode: "methode|http://methode-article-mapper:8080|application/json"
+  article: "article|http://upp-content-validator:8080|application/vnd.ft-upp-article+json"
+  CPH: "CPH|http://upp-content-placeholder-validator:8080|application/vnd.ft-upp-content-placeholder+json"
+
+#methodeDraftConfig: "http://methode-article-mapper:8080|application/json"
+#articleDraftConfig: "http://upp-content-validator:8080|application/vnd.ft-upp-article+json"
+#CPHDraftConfig: "http://upp-content-placeholder-validator:8080|application/vnd.ft-upp-content-placeholder+json"
+
 eksCluster: false
 
 replicaCount: 2

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Financial-Times/http-handlers-go/httphandlers"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
 	"github.com/husobee/vestigo"
-	"github.com/jawher/mow.cli"
+	cli "github.com/jawher/mow.cli"
 	"github.com/rcrowley/go-metrics"
 	log "github.com/sirupsen/logrus"
 )
@@ -71,6 +71,13 @@ func main() {
 		EnvVar: "DRAFT_CONTENT_UCV_ENDPOINT",
 	})
 
+	ucpvEndpoint := app.String(cli.StringOpt{
+		Name:   "ucpv-endpoint",
+		Value:  "http://localhost:9877",
+		Desc:   "Endpoint for mapping Spark/CCT content placeholder draft content",
+		EnvVar: "DRAFT_CONTENT_PLACEHOLDER_UCV_ENDPOINT",
+	})
+
 	contentEndpoint := app.String(cli.StringOpt{
 		Name:   "content-endpoint",
 		Value:  "http://test.api.ft.com/content",
@@ -110,12 +117,14 @@ func main() {
 
 		mamService := content.NewDraftContentMapperService(*mamEndpoint, httpClient)
 		ucvService := content.NewSparkDraftContentMapperService(*ucvEndpoint, httpClient)
+		ucpvService := content.NewSparkDraftContentMapperService(*ucpvEndpoint, httpClient)
 
 		originIdMapping := map[string]content.DraftContentMapper{
 			"methode-web-pub": mamService,
 		}
 		contentTypeMapping := map[string]content.DraftContentMapper{
-			"application/vnd.ft-upp-article+json": ucvService,
+			"application/vnd.ft-upp-article+json":             ucvService,
+			"application/vnd.ft-upp-content-placeholder+json": ucpvService,
 		}
 
 		resolver := content.NewDraftContentMapperResolver(originIdMapping, contentTypeMapping)


### PR DESCRIPTION
Excluding the configuration improvements the following business logic has changed :

* Added new content type for validation : application/vnd.ft-upp-content-placeholder+json

* Added new origin IDs : spark, spark-lists

* Decoupling originID from the mapper validation. The service used to be able to retrieve a mapper from the originID in case it fails getting it from its content-type. This
This approach is no longer valid, since spark has multiple originTypes that allows it to create multiple content.

Another important point is that there isn’t a check to correlate Content-Type with OriginID 
e.g: if Methode (origin ID) tries to create a spark-article (content Type) is a valid operation, it was that way and it still work the same way, no business logic has changed (we have agreed on that).


Old valid request combination:

- Methode 
Content-Type: methode-web-pub
X-Origin-System-Id: application/json

- Spark
Content-Type: cct
X-Origin-System-Id: application/vnd.ft-upp-article+json

New valid request combination:

- Methode 
Content-Type: methode-web-pub
X-Origin-System-Id: application/json

- Spark
Content-Type: cct || spark-lists || spark
X-Origin-System-Id: application/vnd.ft-upp-article+json || application/vnd.ft-upp-content-placeholder+json

Regarding the config improvements, adding new origin IDs and content types -is much easier - complying with our load policy. 

Last but not least, there are some comments in the code in order to make the review easier, will be removed before merging.

Update: when creating content, as mentioned above it gets validated that it has a valid content-Type —it might not be its type, just a valid one eg: creating an article with CT of a CPH- . The data is written into an Aurora DB, the problem comes when reading, because then it does a validation whether the content type that has been sent and written into Aurora matches the data, if does not match it returns an error, so its easier to write since there is no validation content-type header body content, instead such validations are being done when reading content  ! That’s a bug and need to be fixed.
