### PR TITLE
Add transformation for main image from DocStore

### DIFF
--- a/content/handler.go
+++ b/content/handler.go
@@ -37,8 +37,8 @@ type Handler struct {
 	timeout       time.Duration
 }
 
-func NewHandler(uppApi ContentAPI, draftContentRW DraftContentRW, timeout time.Duration) *Handler {
-	return &Handler{uppApi, draftContentRW, timeout}
+func NewHandler(uppAPI ContentAPI, draftContentRW DraftContentRW, timeout time.Duration) *Handler {
+	return &Handler{uppAPI, draftContentRW, timeout}
 }
 
 func (h *Handler) ReadContent(w http.ResponseWriter, r *http.Request) {
@@ -187,8 +187,7 @@ func (h *Handler) readContentFromUPP(ctx context.Context, w http.ResponseWriter,
 		writeMessage(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	err = transformUPPContent(uppContent)
+	err = h.transformUPPContent(uppContent)
 
 	if err != nil {
 		readContentUPPLog.WithError(err).Error("Failed transforming UPP response")
@@ -264,12 +263,14 @@ func writeMessage(w http.ResponseWriter, errMsg string, status int) {
 }
 
 // Function modifies these fields/values;
-//  - id -> uuid, removing the http prefix
-//  - bodyXML -> body, keeping value intact
-//  - type value, removing http prefix
-//  - brands value, adding an object wrapper with id field having the same value
-func transformUPPContent(content map[string]interface{}) error {
-
+//   - id -> uuid, removing the http prefix
+//   - bodyXML -> body, keeping value intact
+//   - type value, removing http prefix
+//   - brands value, adding an object wrapper with id field having the same value
+//   - mainImage, converting to string and removing the endpoint prefix
+//
+//nolint:gocognit
+func (h *Handler) transformUPPContent(content map[string]interface{}) error {
 	// --- uuid
 	if id, present := content["id"]; present {
 		uniqueId, assertion := id.(string)
@@ -324,6 +325,20 @@ func transformUPPContent(content map[string]interface{}) error {
 
 		content["brands"] = idBrandTuples
 
+		// --- mainImage
+		if mainImage, present := content["mainImage"]; present {
+			imageMap, assertion := mainImage.(map[string]interface{})
+			if !assertion {
+				return fmt.Errorf("invalid mainImage entry, was expecting a map, got: %s", mainImage)
+			}
+			if id, exists := imageMap["id"]; exists {
+				idString := id.(string)
+				imageUUID := idString[strings.LastIndex(idString, "/")+1:]
+				content["mainImage"] = imageUUID
+			} else {
+				return fmt.Errorf("invalid mainImage entry, was expecting an id-value pair")
+			}
+		}
 	}
 
 	return nil

--- a/content/handler_test.go
+++ b/content/handler_test.go
@@ -63,6 +63,7 @@ func TestHappyRead(t *testing.T) {
 
 func TestReadBackOffWhenNoDraftFoundToContentAPI(t *testing.T) {
 	contentUUID := "83a201c6-60cd-11e7-91a7-502f7ee26895"
+	mainImageUUID := "fba9884e-0756-11e8-0074-38e932af9738"
 
 	rw := &mockDraftContentRW{}
 	rw.On("Read", mock.Anything, contentUUID).Return(nil, ErrDraftNotFound)
@@ -105,7 +106,7 @@ func TestReadBackOffWhenNoDraftFoundToContentAPI(t *testing.T) {
 	assert.NotEmpty(t, actualBody)
 
 	assert.Equal(t, "Article", actual["type"])
-
+	assert.Equal(t, mainImageUUID, actual["mainImage"])
 	rw.AssertExpectations(t)
 }
 


### PR DESCRIPTION
This PR fixes the mapping of manImage fetched from document store. Another step to resolve the issue will be to update the key that the service is using to include the INCLUDE_RICH_CONTENT and INCLUDE_LITE policies

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3586

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)