### PR TITLE
Feature/uppsf 3585 add lite object draf

### DIFF
--- a/content/handler.go
+++ b/content/handler.go
@@ -187,6 +187,7 @@ func (h *Handler) readContentFromUPP(ctx context.Context, w http.ResponseWriter,
 		writeMessage(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	err = h.transformUPPContent(uppContent)
 
 	if err != nil {
@@ -268,6 +269,7 @@ func writeMessage(w http.ResponseWriter, errMsg string, status int) {
 //   - type value, removing http prefix
 //   - brands value, adding an object wrapper with id field having the same value
 //   - mainImage, converting to string and removing the endpoint prefix
+//   - annotations by removing it
 //
 //nolint:gocognit
 func (h *Handler) transformUPPContent(content map[string]interface{}) error {
@@ -340,6 +342,9 @@ func (h *Handler) transformUPPContent(content map[string]interface{}) error {
 			}
 		}
 	}
+
+	// --- annotation
+	delete(content, "annotations")
 
 	return nil
 

--- a/helm/draft-content-api/templates/deployment.yaml
+++ b/helm/draft-content-api/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: global-config
-              key: content-endpoint
+              key: internal-content-endpoint
         - name: APP_TIMEOUT
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
# Description

## What

Changing the endpoint to get the drafts from `content-endpoint` to `content-internal-endpoint` in order to have the `lite` field in the response.

## Why

As requested [in the #spark-upp Slack channel](https://financialtimes.slack.com/archives/CABF5KB0Q/p1665055389403079), the Spark team needs a lite object (same as the one in the internal content endpoint, see below) added to the /drafts/content endpoint (https://api-t.ft.com/drafts/content/${:articleId}) . This should be included if INCLUDE_LITE x-policy is added.

https://financialtimes.atlassian.net/browse/UPPSF-3585

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)